### PR TITLE
fix: 修复vue-cli3.0项目端口被占用的bug #97

### DIFF
--- a/preview/dist/index.html
+++ b/preview/dist/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>骨架页面预览</title>
-<link href="main.4da48e9f37a58e077c95.css" rel="stylesheet"></head>
+<link href="main.f8a2e0bbbc6188d97f17.css" rel="stylesheet"></head>
 <body>
   <div id="app"></div>
-<script type="text/javascript" src="bundle.4da48e9f37a58e077c95.js"></script></body>
+<script type="text/javascript" src="bundle.f8a2e0bbbc6188d97f17.js"></script></body>
 </html>

--- a/src/skeletonPlugin.js
+++ b/src/skeletonPlugin.js
@@ -23,8 +23,10 @@ function SkeletonPlugin(options = {}) {
 }
 
 SkeletonPlugin.prototype.createServer = function () { // eslint-disable-line func-names
-  const server = this.server = new Server(this.options) // eslint-disable-line no-multi-assign
-  server.listen().catch(err => server.log.warn(err))
+  if (!this.server) {
+    const server = this.server = new Server(this.options) // eslint-disable-line no-multi-assign
+    server.listen().catch(err => server.log.warn(err))
+  }
 }
 
 SkeletonPlugin.prototype.insertScriptToClient = function (htmlPluginData) { // eslint-disable-line func-names


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | yes
| New tests added? | not needed
| Fixed tickets    | comma-separated list of tickets fixed by the PR, if any
| License          | MIT

### Description

修复vue-cli3.0项目， 端口被占用的bug；
测试发现compiler.hooks.entryOption被执了两次，没找到执行两次的原因
于是：在`createServer`方法中判断插件的server是否被创建，没创建的时，
正常执行，创建过就什么都不做了

--

#### Please, don't submit `/dist` files with your PR!
