### PR TITLE
feat: 支持 NODE_ENV 多环境变量

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ All examples are in the `examples` folder.
 Use `npm` to install this plugin, and you also need to install [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin).
 
 > npm install --save-dev page-skeleton-webpack-plugin
-> 
+>
 > npm install --save-dev html-webpack-plugin
 
 ### Basic Use
@@ -197,6 +197,8 @@ Re-package the application with webpack. When the page is restarted, you can see
 | quiet     | Boolean         | No        | `false`      | Whether to print messages on the terminal, when set to true, no messages are printed. |
 | noInfo    | Boolean         | No        | `false`      | When the value is `true`, plugin will not print `info` message. |
 | logTime   | Boolean         | No        | `true`       | Print formatted time before the message.                     |
+| productionMode | Array      | No        | `['production']` | Set NODE_ENV string can be build production mode, it can be `['develop', 'test', 'staging', 'production']` or any NODE_ENV string. |
+
 
 **Skeleton Page Options**
 
@@ -240,7 +242,7 @@ const pluginDefaultConfig = {
   },
   button: {
     color: '#EFEFEF',
-    excludes: [] 
+    excludes: []
   },
   svg: {
     color: '#EFEFEF',
@@ -272,7 +274,8 @@ const pluginDefaultConfig = {
   logLevel: 'info',
   quiet: false,
   noInfo: false,
-  logTime: true
+  logTime: true,
+  productionMode: ['production'] // ['develop', 'test', 'staging', 'production'],
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/raw/master/docs/banner.jpg" alt="mark text" width="100%">
+<img src="https://github.com/kingzez/page-skeleton-webpack-plugin/raw/node-env-editable/docs/banner.jpg" alt="mark text" width="100%">
 </p>
 
 # Different from [page-skeleton-webpack-plugin](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable) is *Multiple NODE_ENV String*
@@ -48,7 +48,7 @@
       Blog
     </a>
    <span> | </span>
-    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/blob/master/docs/i18n/zh_cn.md">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/blob/node-env-editable/docs/i18n/zh_cn.md">
       中文
     </a>
    <span> | </span>
@@ -80,7 +80,7 @@
 
 <br />
 
-![](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/raw/master/docs/workflow.gif)
+![](https://github.com/kingzez/page-skeleton-webpack-plugin/raw/node-env-editable/docs/workflow.gif)
 
 ### Features
 
@@ -104,7 +104,7 @@ _speed up play_
 
 All examples are in the `examples` folder.
 
-* [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/tree/master/examples/sale)
+* [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/examples/sale)
 
 ### Installation
 
@@ -195,7 +195,7 @@ Re-package the application with webpack. When the page is restarted, you can see
 | --------- | --------------- | --------- | ------------ | ------------------------------------------------------------ |
 | pathname  | String          | Yes       | None         | Where the shell.html file shoud be output.                   |
 | staticDir | String          | Yes       | None         | Path to output static route page                             |
-| routes    | Array           | Yes       | None         | Route in `routes ` will generate static route with skeleton screen, please refer to [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/tree/master/examples/sale) |
+| routes    | Array           | Yes       | None         | Route in `routes ` will generate static route with skeleton screen, please refer to [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/examples/sale) |
 | Port      | String          | No        | 8989         | The port of Page Skeleton server                             |
 | debug     | Boolean         | No        | `true`       | Whether debug mode is enabled or not, when debug is true, the output of the headless Chromium console will be output on the terminal. |
 | minify    | false or Object | No        | See defaults | The plug-in will uglify the generated shell.html file by default. You can pass [html-minifier](https://github.com/kangax/html-minifier) configuration parameters to mimify shell.html. When configured to false , the generated shell.html file is not uglified and the shell.html file is formatted. |
@@ -301,6 +301,6 @@ Special thanks to @Yasujizr who designed the banner of Page Skeleton.
 
 ### License
 
- [**MIT**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/blob/master/LICENSE).
+ [**MIT**](https://github.com/kingzez/page-skeleton-webpack-plugin/blob/node-env-editable/LICENSE).
 
 Copyright (c) 2017-present, @ElemeFE

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 <p align="center">
-<img src="https://github.com/ElemeFE/page-skeleton-webpack-plugin/raw/master/docs/banner.jpg" alt="mark text" width="100%">
+<img src="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/raw/master/docs/banner.jpg" alt="mark text" width="100%">
 </p>
+
+# Different from [page-skeleton-webpack-plugin](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable) is *Multiple NODE_ENV String*
+
+## See details
+- [PR](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/pull/110) I had pull request, but have no response, so I publish for temporary
+- [Document productionMode](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#documents)
 
 <div align="center">
   <strong>:high_brightness:Automatically generate Skeleton Page:crescent_moon:</strong>
@@ -14,19 +20,19 @@
 
 <div align="center">
   <!-- Version -->
-  <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin">
+  <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable">
     <img src="https://badge.fury.io/gh/elemefe%2Fpage-skeleton-webpack-plugin.svg" alt="website">
   </a>
   <!-- License -->
-  <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin">
+  <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable">
     <img src="https://img.shields.io/github/license/ElemeFE/page-skeleton-webpack-plugin.svg?style=flat-square" alt="LICENSE">
   </a>
   <!-- Build Status -->
-  <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin">
+  <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable">
     <img src="https://travis-ci.org/ElemeFE/page-skeleton-webpack-plugin.svg?branch=master" alt="build">
   </a>
   <!-- Downloads monthly -->
-  <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin">
+  <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable">
     <img src="https://img.shields.io/npm/dm/page-skeleton-webpack-plugin.svg?style=flat-square" alt="download">
   </a>
 </div>
@@ -42,31 +48,31 @@
       Blog
     </a>
    <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin/blob/master/docs/i18n/zh_cn.md">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/blob/master/docs/i18n/zh_cn.md">
       中文
     </a>
    <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#features">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#features">
       Features
     </a>
    <span> | </span>
-​    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#examples">
+​    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#examples">
       Examples
     </a>
 ​    <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#installation">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#installation">
       Install
     </a>
     <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#basic-use">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#basic-use">
       Basic Use
     </a>
     <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#documents">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#documents">
       Documents
     </a>
     <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#contribution">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#contribution">
       Contribution
     </a>
   </h3>
@@ -74,7 +80,7 @@
 
 <br />
 
-![](https://github.com/ElemeFE/page-skeleton-webpack-plugin/raw/master/docs/workflow.gif)
+![](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/raw/master/docs/workflow.gif)
 
 ### Features
 
@@ -98,7 +104,7 @@ _speed up play_
 
 All examples are in the `examples` folder.
 
-* [**sale**](https://github.com/ElemeFE/page-skeleton-webpack-plugin/tree/master/examples/sale)
+* [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/tree/master/examples/sale)
 
 ### Installation
 
@@ -189,7 +195,7 @@ Re-package the application with webpack. When the page is restarted, you can see
 | --------- | --------------- | --------- | ------------ | ------------------------------------------------------------ |
 | pathname  | String          | Yes       | None         | Where the shell.html file shoud be output.                   |
 | staticDir | String          | Yes       | None         | Path to output static route page                             |
-| routes    | Array           | Yes       | None         | Route in `routes ` will generate static route with skeleton screen, please refer to [**sale**](https://github.com/ElemeFE/page-skeleton-webpack-plugin/tree/master/examples/sale) |
+| routes    | Array           | Yes       | None         | Route in `routes ` will generate static route with skeleton screen, please refer to [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/tree/master/examples/sale) |
 | Port      | String          | No        | 8989         | The port of Page Skeleton server                             |
 | debug     | Boolean         | No        | `true`       | Whether debug mode is enabled or not, when debug is true, the output of the headless Chromium console will be output on the terminal. |
 | minify    | false or Object | No        | See defaults | The plug-in will uglify the generated shell.html file by default. You can pass [html-minifier](https://github.com/kangax/html-minifier) configuration parameters to mimify shell.html. When configured to false , the generated shell.html file is not uglified and the shell.html file is formatted. |
@@ -197,8 +203,6 @@ Re-package the application with webpack. When the page is restarted, you can see
 | quiet     | Boolean         | No        | `false`      | Whether to print messages on the terminal, when set to true, no messages are printed. |
 | noInfo    | Boolean         | No        | `false`      | When the value is `true`, plugin will not print `info` message. |
 | logTime   | Boolean         | No        | `true`       | Print formatted time before the message.                     |
-| productionMode | Array      | No        | `['production']` | Set NODE_ENV string can be build production mode, it can be `['develop', 'test', 'staging', 'production']` or any NODE_ENV string. |
-
 
 **Skeleton Page Options**
 
@@ -274,8 +278,7 @@ const pluginDefaultConfig = {
   logLevel: 'info',
   quiet: false,
   noInfo: false,
-  logTime: true,
-  productionMode: ['production'] // ['develop', 'test', 'staging', 'production'],
+  logTime: true
 }
 ```
 
@@ -298,6 +301,6 @@ Special thanks to @Yasujizr who designed the banner of Page Skeleton.
 
 ### License
 
- [**MIT**](https://github.com/ElemeFE/page-skeleton-webpack-plugin/blob/master/LICENSE).
+ [**MIT**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/blob/master/LICENSE).
 
 Copyright (c) 2017-present, @ElemeFE

--- a/docs/i18n/zh_cn.md
+++ b/docs/i18n/zh_cn.md
@@ -1,6 +1,12 @@
 <p align="center">
-<img src="https://github.com/ElemeFE/page-skeleton-webpack-plugin/raw/master/docs/banner.jpg" alt="mark text" width="100%">
+<img src="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/raw/master/docs/banner.jpg" alt="mark text" width="100%">
 </p>
+
+# 与 [page-skeleton-webpack-plugin](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable) 不同的是可以设置 *多 NODE_ENV环境变量已生成 production 模式*
+
+## 详见
+- [PR](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/pull/110) 提了一个pr，官方暂无回应，因此只能自己发布
+- [文档 productionMode](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#documents)
 
 <div align="center">
   <strong>:high_brightness:Automatically generate Skeleton Page:crescent_moon:</strong>
@@ -14,19 +20,19 @@
 
 <div align="center">
   <!-- Version -->
-  <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin">
+  <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable">
     <img src="https://badge.fury.io/gh/elemefe%2Fpage-skeleton-webpack-plugin.svg" alt="website">
   </a>
   <!-- License -->
-  <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin">
+  <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable">
     <img src="https://img.shields.io/github/license/ElemeFE/page-skeleton-webpack-plugin.svg?style=flat-square" alt="LICENSE">
   </a>
   <!-- Build Status -->
-  <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin">
+  <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable">
     <img src="https://travis-ci.org/ElemeFE/page-skeleton-webpack-plugin.svg?branch=master" alt="build">
   </a>
   <!-- Downloads weekly -->
-  <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin">
+  <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable">
     <img src="https://img.shields.io/npm/dw/page-skeleton-webpack-plugin.svg?style=flat-square" alt="download">
   </a>
 </div>
@@ -37,27 +43,27 @@
 
 <div align="center">
   <h3>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#features">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#features">
       Features
     </a>
    <span> | </span>
-​    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#examples">
+​    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#examples">
       Examples
     </a>
 ​    <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#installation">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#installation">
       Install
     </a>
     <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#basic-use">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#basic-use">
       Basic Use
     </a>
     <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#documents">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#documents">
       Documents
     </a>
     <span> | </span>
-    <a href="https://github.com/ElemeFE/page-skeleton-webpack-plugin#contribution">
+    <a href="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable#contribution">
       Contribution
     </a>
   </h3>
@@ -65,7 +71,7 @@
 
 <br />
 
-![](https://github.com/ElemeFE/page-skeleton-webpack-plugin/raw/master/docs/workflow.gif)
+![](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/raw/master/docs/workflow.gif)
 
 ### Features
 
@@ -81,7 +87,7 @@ Page Skeleton 是一款 webpack 插件，该插件的目的是根据你项目中
 
 所有的 example 都放在了 `examples` 文件夹内。
 
-* [**sale**](https://github.com/ElemeFE/page-skeleton-webpack-plugin/tree/master/examples/sale)
+* [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/tree/master/examples/sale)
 
 ### Installation
 
@@ -173,7 +179,7 @@ const webpackConfig = {
 | --------- | --------------- | --------- | ------------ | ------------------------------------------------------------ |
 | pathname  | String          | Yes       | None         | Where the shell.html file shoud be output.                   |
 | staticDir | String          | Yes       | None         | 用来输出静态路由页面的路径                                   |
-| routes    | Array           | Yes       | None         | 需要生成带有骨架屏的静态路由，请参考 [**sale**](https://github.com/ElemeFE/page-skeleton-webpack-plugin/tree/master/examples/sale) |
+| routes    | Array           | Yes       | None         | 需要生成带有骨架屏的静态路由，请参考 [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/tree/master/examples/sale) |
 | Port      | String          | No        | 8989         | The port of Page Skeleton server                             |
 | debug     | Boolean         | No        | true         | 是否开启 `debug` 模式，当 `debug` 为 `true` 时，headless Chromium 控制台的输出信息将在终端输出。 |
 | minify    | false or Object | No        | See defaults | 插件默认会压缩生成的 shell.html 文件，默认压缩配置参见本部分默认配置。可以传递 [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference) 的配置参数给 `mimify`，进行按需压缩。当配置为 false 时，不压缩生成的 shell.html 文件，并且会对 shell.html 文件进行格式化处理。 |
@@ -181,7 +187,6 @@ const webpackConfig = {
 | quiet     | Boolean         | No        | `false`      | 是否在终端打印消息，当设置为 true 时，不打印任何消息。       |
 | noInfo    | Boolean         | No        | `false`      | 当设置为 true 时，不打印 `info` 类型的消息                   |
 | logTime   | Boolean         | No        | `true`       | 当设置为 true 时，在任何消息前面都会带有一个格式化的时间值。 |
-| productionMode | Array      | No        | `['production']` | 用来设置 NODE_ENV 多环境生产模式，可以设置 `['develop', 'test', 'staging', 'production']`, 可自定义生产模式的环境变量。 |
 
 **Skeleton Page Options**
 
@@ -270,6 +275,6 @@ Special thanks to @Yasujizr who designed the banner of Page Skeleton.
 
 ### License
 
- [**MIT**](https://github.com/ElemeFE/page-skeleton-webpack-plugin/blob/master/LICENSE).
+ [**MIT**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/blob/master/LICENSE).
 
 Copyright (c) 2017-present, @ElemeFE

--- a/docs/i18n/zh_cn.md
+++ b/docs/i18n/zh_cn.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/raw/master/docs/banner.jpg" alt="mark text" width="100%">
+<img src="https://github.com/kingzez/page-skeleton-webpack-plugin/raw/node-env-editable/docs/banner.jpg" alt="mark text" width="100%">
 </p>
 
 # 与 [page-skeleton-webpack-plugin](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable) 不同的是可以设置 *多 NODE_ENV环境变量已生成 production 模式*
@@ -71,7 +71,7 @@
 
 <br />
 
-![](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/raw/master/docs/workflow.gif)
+![](https://github.com/kingzez/page-skeleton-webpack-plugin/raw/node-env-editable/docs/workflow.gif)
 
 ### Features
 
@@ -87,7 +87,7 @@ Page Skeleton 是一款 webpack 插件，该插件的目的是根据你项目中
 
 所有的 example 都放在了 `examples` 文件夹内。
 
-* [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/tree/master/examples/sale)
+* [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/examples/sale)
 
 ### Installation
 
@@ -179,7 +179,7 @@ const webpackConfig = {
 | --------- | --------------- | --------- | ------------ | ------------------------------------------------------------ |
 | pathname  | String          | Yes       | None         | Where the shell.html file shoud be output.                   |
 | staticDir | String          | Yes       | None         | 用来输出静态路由页面的路径                                   |
-| routes    | Array           | Yes       | None         | 需要生成带有骨架屏的静态路由，请参考 [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/tree/master/examples/sale) |
+| routes    | Array           | Yes       | None         | 需要生成带有骨架屏的静态路由，请参考 [**sale**](https://github.com/kingzez/page-skeleton-webpack-plugin/tree/node-env-editable/examples/sale) |
 | Port      | String          | No        | 8989         | The port of Page Skeleton server                             |
 | debug     | Boolean         | No        | true         | 是否开启 `debug` 模式，当 `debug` 为 `true` 时，headless Chromium 控制台的输出信息将在终端输出。 |
 | minify    | false or Object | No        | See defaults | 插件默认会压缩生成的 shell.html 文件，默认压缩配置参见本部分默认配置。可以传递 [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference) 的配置参数给 `mimify`，进行按需压缩。当配置为 false 时，不压缩生成的 shell.html 文件，并且会对 shell.html 文件进行格式化处理。 |

--- a/docs/i18n/zh_cn.md
+++ b/docs/i18n/zh_cn.md
@@ -88,7 +88,7 @@ Page Skeleton 是一款 webpack 插件，该插件的目的是根据你项目中
 通过 npm 来安装插件及依赖，该插件依赖于 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)。
 
 > npm install --save-dev page-skeleton-webpack-plugin
-> 
+>
 > npm install --save-dev html-webpack-plugin
 
 ### Basic Use
@@ -181,6 +181,7 @@ const webpackConfig = {
 | quiet     | Boolean         | No        | `false`      | 是否在终端打印消息，当设置为 true 时，不打印任何消息。       |
 | noInfo    | Boolean         | No        | `false`      | 当设置为 true 时，不打印 `info` 类型的消息                   |
 | logTime   | Boolean         | No        | `true`       | 当设置为 true 时，在任何消息前面都会带有一个格式化的时间值。 |
+| productionMode | Array      | No        | `['production']` | 用来设置 NODE_ENV 多环境生产模式，可以设置 `['develop', 'test', 'staging', 'production']`, 可自定义生产模式的环境变量。 |
 
 **Skeleton Page Options**
 
@@ -225,7 +226,7 @@ const pluginDefaultConfig = {
   },
   button: {
     color: '#EFEFEF',
-    excludes: [] 
+    excludes: []
   },
   svg: {
     color: '#EFEFEF',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "page-skeleton-webpack-plugin",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "page-skeleton-webpack-plugin",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -582,6 +582,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -5421,7 +5422,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5442,12 +5444,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5462,17 +5466,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5589,7 +5596,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5601,6 +5609,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5615,6 +5624,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5622,12 +5632,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5646,6 +5658,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5726,7 +5739,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5738,6 +5752,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5823,7 +5838,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5859,6 +5875,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5878,6 +5895,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5921,12 +5939,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7994,7 +8014,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "page-skeleton-webpack-plugin",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-skeleton-with-env-webpack-plugin",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "web site skeleton generator",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "page-skeleton-webpack-plugin",
+  "name": "page-skeleton-with-env-webpack-plugin",
   "version": "0.10.12",
   "description": "web site skeleton generator",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-skeleton-with-env-webpack-plugin",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "web site skeleton generator",
   "main": "index.js",
   "scripts": {

--- a/preview/dist/index.html
+++ b/preview/dist/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>骨架页面预览</title>
-<link href="main.4da48e9f37a58e077c95.css" rel="stylesheet"></head>
+<link href="main.f8a2e0bbbc6188d97f17.css" rel="stylesheet"></head>
 <body>
   <div id="app"></div>
-<script type="text/javascript" src="bundle.4da48e9f37a58e077c95.js"></script></body>
+<script type="text/javascript" src="bundle.f8a2e0bbbc6188d97f17.js"></script></body>
 </html>

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -55,7 +55,9 @@ const defaultOptions = {
   logLevel: 'info',
   quiet: false,
   noInfo: false,
-  logTime: true
+  logTime: true,
+  productionMode: ['production']
+  // ['develop', 'test', 'staging', 'production'],
 }
 
 const htmlBeautifyConfig = {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -57,7 +57,7 @@ const defaultOptions = {
   noInfo: false,
   logTime: true,
   productionMode: ['production']
-  // ['develop', 'test', 'staging', 'production'],
+  // can be ['develop', 'test', 'staging', 'production'] or more NODE_ENV string,
 }
 
 const htmlBeautifyConfig = {

--- a/src/config/optionsSchema.json
+++ b/src/config/optionsSchema.json
@@ -102,11 +102,11 @@
     },
     "device": {
       "description": "The device you want to generate skeleton page",
-      "type": "string"     
+      "type": "string"
     },
     "debug": {
       "description": "Weather to show debug info",
-      "type": "boolean"     
+      "type": "boolean"
     },
     "minify": {
       "description": "Weather to minify the HTML",
@@ -114,35 +114,35 @@
         "type": "object"
       }, {
         "type": "boolean"
-      }]   
+      }]
     },
     "defer": {
       "description": "Defer to generate skeleton page",
-      "type": "number"     
+      "type": "number"
     },
     "excludes": {
       "description": "which element that you dont want to generate skeleton",
-      "type": "array"     
+      "type": "array"
     },
     "remove": {
       "description": "the elements that you want to remove",
-      "type": "array"     
+      "type": "array"
     },
     "hide": {
       "description": "the element that you want to hide",
-      "type": "array"     
+      "type": "array"
     },
     "grayBlock": {
       "description": "the element that you just want to make it display a gray block",
-      "type": "array"     
+      "type": "array"
     },
     "cookies": {
       "description": "Add cookies to the page which puppeteer opened",
-      "type": "array"     
+      "type": "array"
     },
     "headless": {
       "description": "Open headless chrome or not",
-      "type": "boolean"     
+      "type": "boolean"
     },
     "cssUnit": {
       "description": "The css unit used in shell.html",
@@ -152,7 +152,7 @@
         "vh",
         "vmin",
         "vmax"
-      ]  
+      ]
     },
     "decimal": {
       "description": "The decimal of CSS value",
@@ -188,6 +188,10 @@
     "sessionStoragies": {
       "description": "Add sessionStorage to the page after puppeter opened",
       "type": "object"
+    },
+    "productionMode": {
+      "description": "Add production mode NODE_ENV string for webpack",
+      "type": "array"
     }
   },
   "type": "object"

--- a/src/skeletonPlugin.js
+++ b/src/skeletonPlugin.js
@@ -9,7 +9,7 @@ const { addScriptTag, outputSkeletonScreen, snakeToCamel } = require('./util')
 const { defaultOptions, staticPath } = require('./config/config')
 const OptionsValidationError = require('./config/optionsValidationError')
 
-const EVENT_LIST = process.env.NODE_ENV === 'production' ? ['watch-close', 'failed', 'done'] : ['watch-close', 'failed']
+let EVENT_LIST
 const PLUGIN_NAME = 'pageSkeletonWebpackPlugin'
 
 function SkeletonPlugin(options = {}) {
@@ -20,6 +20,7 @@ function SkeletonPlugin(options = {}) {
   this.options = merge({ staticPath }, defaultOptions, options)
   this.server = null
   this.originalHtml = ''
+  EVENT_LIST = this.options.productionMode.includes(process.env.NODE_ENV) ? ['watch-close', 'failed', 'done'] : ['watch-close', 'failed']
 }
 
 SkeletonPlugin.prototype.createServer = function () { // eslint-disable-line func-names
@@ -29,8 +30,8 @@ SkeletonPlugin.prototype.createServer = function () { // eslint-disable-line fun
 
 SkeletonPlugin.prototype.insertScriptToClient = function (htmlPluginData) { // eslint-disable-line func-names
   // at develop phase, insert the interface code
-  if (process.env.NODE_ENV !== 'production') {
-    const { port } = this.options
+  const { port, productionMode } = this.options
+  if (!productionMode.includes(process.env.NODE_ENV)) {
     const clientEntry = `http://localhost:${port}/${staticPath}/index.bundle.js`
     const oldHtml = htmlPluginData.html
     htmlPluginData.html = addScriptTag(oldHtml, clientEntry, port)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| License          | MIT

### Description
[Description of the feature]
NODE_ENV 环境可配置，有一种情况是这样的
- development: 开发环境
- develop: 线上开发环境
- test：线上测试环境
- production：正式环境

develop，test，production 都是需要构建成 dist bundle 的，目前[skeletonPlugin.js#L32](https://github.com/ElemeFE/page-skeleton-webpack-plugin/blob/master/src/skeletonPlugin.js#L32) 中只要是非 production 环境 都会插入script 引入动态骨架文件，
[skeletonPlugin.js#L12](https://github.com/ElemeFE/page-skeleton-webpack-plugin/blob/master/src/skeletonPlugin.js#L12) 不会close 掉 skeleton server


### 使用方法
```javascript
new SkeletonPlugin({
  productionMode: ['develop', 'test', 'staging', 'production'],
  pathname: path.resolve(__dirname, '../shell')
  staticDir: path.resolve(__dirname, '../dist')
   ...
})
```
以上设置便可以在 `NODE_ENV` 为 `['develop', 'test', 'staging', 'production']` 其中一种的情况下，都可构建出生产环境下的 bundle。